### PR TITLE
feat: Doppler API support and improved error reporting (DEVRL-410)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # IDEs
 .idea
+.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Changed supported Python version to >= 3.6
 
-## 0.3.0 June 21, 2022
+## 0.3.0 June 24, 2022
 
 - Improved error reporting
 - Support for fetching secrets using the Doppler API if `DOPPLER_TOKEN` environment variable set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 0.1.1 (May 4, 2021)
+
+- Initial release
+
+## 0.2.0 May 05, 2021
+
+- README updates
+
+## 0.2.0 May 05, 2021
+
+- README updates
+
+## 0.2.1 May 05, 2021
+
+- README updates
+
+## 0.2.2 May 07, 2021
+
+- Changed supported Python version to >= 3.6
+
+## 0.3.0 June 21, 2022
+
+- Improved error reporting
+- Support for fetching secrets using the Doppler API if `DOPPLER_TOKEN` environment variable set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@
 
 - Changed supported Python version to >= 3.6
 
-## 0.3.0 June 24, 2022
+## 0.3.0 June 23, 2022
 
+- Fetch secrets from Doppler API if `DOPPLER_TOKEN` environment variable set
 - Improved error reporting
-- Support for fetching secrets using the Doppler API if `DOPPLER_TOKEN` environment variable set
+- Check that Doppler CLI is installed
+- Add support for CLI and Personal tokens
+- Improved README
+- Fix paths issue preventing wheel build on Windows

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,21 @@
-.PHONY: clean-pyc clean-build test
+SHELL=/bin/bash
+VENVDIR?=${HOME}/.virtualenvs
+WORKDIR?=$(shell basename "$$PWD")
+VENV?=$(VENVDIR)/$(WORKDIR)/bin
+PYTHON?=$(VENV)/python
+ACTIVATE?=$(VENV)/activate
+
+.PHONY: create-virtual-env activate clean-pyc clean-build test
+
+create-virtual-env:
+	mkdir -p ~/.virtualenvs && \
+	python3 -m venv $(VENVDIR)/$(WORKDIR) && \
+	. $(ACTIVATE) && \
+	pip install --upgrade pip setuptools && \
+	pip install -r requirements.txt
+
+activate:
+	. $(ACTIVATE)
 
 build:
 	python -m build .
@@ -16,8 +33,8 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 flake8:
-	flake8 .
+	. $(ACTIVATE) flake8 .
 
 black:
-	black --skip-string-normalization --line-length 120 .
+	. $(ACTIVATE) black --skip-string-normalization --line-length 120 .
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ activate:
 	. $(ACTIVATE)
 
 build:
-	. $(ACTIVATE) python -m build .
+	. $(ACTIVATE) && python -m build .
 
 clean: clean-build clean-pyc
 
@@ -33,8 +33,8 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 flake8:
-	. $(ACTIVATE) flake8 .
+	. $(ACTIVATE) && flake8 .
 
 black:
-	. $(ACTIVATE) black --skip-string-normalization --line-length 120 .
+	. $(ACTIVATE) && black --skip-string-normalization --line-length 120 .
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ACTIVATE?=$(VENV)/activate
 .PHONY: create-virtual-env activate clean-pyc clean-build test
 
 create-virtual-env:
-	mkdir -p ~/.virtualenvs && \
+	mkdir -p $(VENVDIR) && \
 	python3 -m venv $(VENVDIR)/$(WORKDIR) && \
 	. $(ACTIVATE) && \
 	pip install --upgrade pip setuptools && \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ activate:
 	. $(ACTIVATE)
 
 build:
-	python -m build .
+	. $(ACTIVATE) python -m build .
 
 clean: clean-build clean-pyc
 

--- a/README.md
+++ b/README.md
@@ -1,61 +1,75 @@
 # doppler-env
 
-Inject Doppler secrets as environment variables into your Python application during local development with debugging support for PyCharm and Visual Studio Code.
+The doppler-env package automates the injection of Doppler secrets as environment variables into any Python application and works in the terminal, PyCharm, and Visual Studio Code.
+## Motivation
 
-## How it works
+The Doppler CLI provides the easiest method of injecting secrets into your application:
 
-Debugging support in PyCharm and Visual Studio Code is provided by a vendor-specific Python entry-point which prevents the Doppler CLI from being used to directly inject secrets.
+```sh
+doppler run -- python app.py
+```
 
-This limitation may force developers to use insecure practices such as saving secrets to an unencrypted `.env` file—the issue Doppler was created to prevent.
+But when debugging with PyCharm or Visual Studio Code, a vendor-specific Python entry-point is used, preventing the Doppler CLI from acting as the application runner. At Doppler, we go to great lengths to [prevent secrets ending up on developer's machines](https://blog.doppler.com/how-to-prevent-secrets-from-ending-up-on-developers-machines) so downloading secrets to a .env file wasn't an option.
 
-Simply set the `DOPPLER_ENV` environment variable, and the `doppler-env` package will fetch your secrets using the Doppler CLI, injecting them as environment variables before executing your Python code.
+Thanks to Python's [Site configuration hook](https://docs.python.org/3/library/site.html) via a path configuration file, we can replicate the `doppler run` workflow by fetching the secrets via the Doppler CLI (recommended) or API and injecting into your Python application process prior to your code by being executed.
 
-All this while ensuring secrets never touch the file system.
+## Setup
 
-## Requirements
-
-Ensure you have installed the [Doppler CLI](https://docs.doppler.com/docs/enclave-installation) and [created a project in the Doppler dashboard](https://docs.doppler.com/docs/enclave-project-setup).
-
-Then in a local terminal, authorize the Doppler CLI to retrieve secrets from your workplace:
+Ensure you have [installed the Doppler CLI](https://docs.doppler.com/docs/enclave-installation) locally and have [created a Doppler Project](https://docs.doppler.com/docs/create-project). Then authorize the Doppler CLI to retrieve secrets from your workplace by running:
 
 ```sh
 doppler login
 ```
 
-## Getting started
-
-1. If you haven't already, open a new terminal window, change into the repository folder, then configure the Doppler CLI by selecting the project and config to supply secrets for:
-
-```sh
-doppler setup
-```
-
-2. Install `doppler-env` in your local development environment:
+Then install `doppler-env` in your local development environment or add it to the list of dev specific dependencies:
 
 ```sh
 pip install doppler-env
 ```
 
-3. Define the `DOPPLER_ENV` environment variable in your IDE, editor, or terminal:
+## Configuration
+
+First, define the `DOPPLER_ENV` environment variable in your IDE, editor, or terminal to trigger the injection of secrets:
 
 ```sh
 export DOPPLER_ENV=1
 ```
 
-4. Run or debug your application in your IDE, editor, or terminal:
+Then configure which secrets to fetch for your application by either using the CLI in the root directory of your application:
 
 ```sh
-python src/app.py
+doppler setup
+```
+
+Or set the `DOPPLER_PROJECT` and `DOPPLER_CONFIG` environment variables in your debug configuration within PyCharm or Visual Studio Code.
+
+Now whenever the Python interpreter is invoked for your application, secrets will be injected prior to your application being run:
+
+```sh
+python app.py
+
+# >> [doppler-env]: DOPPLER_ENV environment variable set. Fetching secrets using Doppler CLI
+```
+
+In restrictive environments where the use of the Doppler CLI isn't possible, set a `DOPPLER_TOKEN` environment variable with a [Service Token](https://docs.doppler.com/docs/service-tokens) to fetch secrets directly from the Doppler API:
+
+
+```sh
+python app.py
+
+# >> [doppler-env]: DOPPLER_ENV and DOPPLER_TOKEN environment variable set. Fetching secrets from Doppler API
 ```
 
 ## Acknowledgements
 
-This approach to injecting environment variables was inspired by [patch-env](https://github.com/caricalabs/patch-env) and customized to be Doppler specific.
+This approach to injecting environment variables was inspired by [patch-env](https://github.com/caricalabs/patch-env).
 
 ## Issues
 
-For any bug reports, issues, or enhancements, please [create a repository issue](https://github.com/DopplerHQ/python-doppler-env/issues/new).
+For any bug reports, issues, or enhancements, please [create a repository issue]().
 
-## Support
+# Support
 
-Paid subscribers can use in-product support while those on Doppler's free community plan can receive help in our [Community forum](https://community.doppler.com/).
+You can get support in the [Doppler community forum](https://community.doppler.com/), find us on [Twitter](https://twitter.com/doppler), and for bugs or feature requests, [create an issue](https://github.com/DopplerHQ/python-doppler-env/issues/new) on the [DopplerHQ/python-doppler-env](https://github.com/DopplerHQ/python-doppler-env) GitHub repository.
+
+If you need help, either use our in-product support or head over to the [Doppler Community Forum](https://community.doppler.com/) to get your questions answered by a member of the Doppler support team or 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def long_description():
 
 setup(
     name='doppler_env',
-    version='0.2.2',
+    version='0.3.0',
     python_requires='>=3.6',
     description='Inject Doppler secrets as environment variables into your Python application during local development with debugging support for PyCharm and Visual Studio Code.',
     long_description=long_description(),
@@ -31,8 +31,8 @@ setup(
         'Bug Reports': 'https://github.com/dopplerhq/python-doppler-env/issues',
         'Source': 'https://github.com/dopplerhq/python-doppler-env',
     },
-    author='Doppler',
-    author_email='support@doppler.com',
+    author='Ryan Blunden',
+    author_email='ryan.blunden@doppler.com',
     license='APL 2.0',
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     keywords='doppler, environment variables, app secrets, app config, os.environ',
     packages=['doppler_env'],

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
         'Bug Reports': 'https://github.com/dopplerhq/python-doppler-env/issues',
         'Source': 'https://github.com/dopplerhq/python-doppler-env',
     },
-    author='Ryan Blunden',
-    author_email='ryan.blunden@doppler.com',
+    author='Doppler',
+    author_email='support@doppler.com',
     license='APL 2.0',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sysconfig
 import os
 from codecs import open
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,14 @@
-#!/usr/bin/env python3
-"""A setuptools based setup module.
-See:
-https://packaging.python.org/en/latest/distributing.html
-https://github.com/pypa/sampleproject
-"""
-
-# Always prefer setuptools over distutils
+import sysconfig
+import os
 from codecs import open
-from os import path
-
 from setuptools import setup
-
-here = path.abspath(path.dirname(__file__))
-
-
-def long_description():
-    with open(path.join(here, 'README.md'), encoding='utf-8') as readme:
-        return readme.read()
-
 
 setup(
     name='doppler_env',
     version='0.3.0',
     python_requires='>=3.6',
     description='Inject Doppler secrets as environment variables into your Python application during local development with debugging support for PyCharm and Visual Studio Code.',
-    long_description=long_description(),
+    long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/dopplerhq/python-doppler-env',
     project_urls={
@@ -52,5 +36,5 @@ setup(
     install_requires=['pip', 'python-dotenv'],
     extras_require={'dev': ['check-manifest'], 'test': []},
     package_data={},
-    data_files=[('/', ["doppler_env.pth"])],
+    data_files=[(os.path.sep, ["doppler_env.pth"])],
 )

--- a/src/doppler_env/__init__.py
+++ b/src/doppler_env/__init__.py
@@ -20,6 +20,12 @@ def fetch_cli():
         'DOPPLER_ENV_COMMAND', 'doppler secrets download --no-file --format env'
     )
 
+    try:
+        subprocess.check_output('doppler', stderr=subprocess.STDOUT).decode('utf-8')
+    except FileNotFoundError as err:
+        print('The Doppler CLI is not installed. See https://docs.doppler.com/docs/install-cli')
+        return
+
     # If non-zero exit code, catch Python exception so only output is stderr from Doppler CLI
     try:
         return subprocess.check_output(DOPPLER_ENV_COMMAND.split()).decode('utf-8')

--- a/src/doppler_env/__init__.py
+++ b/src/doppler_env/__init__.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import urllib.request
 import urllib.error
+import urllib.parse
 
 from dotenv import load_dotenv
 
@@ -50,16 +51,17 @@ def fetch_api(doppler_token, project=None, config=None):
 
     auth_header = b'Basic %s' % b64encode('{}:'.format(doppler_token).encode('ascii'))
     headers = {'User-Agent': 'python-doppler-env', 'Authorization': auth_header}
-    url = 'https://api.doppler.com/v3/configs/config/secrets/download?format=env'
-    if 'dp.st' not in doppler_token and project and config:
-        url = '{url}&project={project}&config={config}'.format(url=url, project=project, config=config)
+    params = {'format': 'env'}
+    if project and config:
+        params.update({'project': project, 'config': config})
+    url = 'https://api.doppler.com/v3/configs/config/secrets/download?{}'.format(urllib.parse.urlencode(params))
 
     try:
         request = urllib.request.Request(url, headers=headers)
         response = urllib.request.urlopen(request)
         return response.read().decode('utf-8')
     except urllib.error.HTTPError as err:
-        log('Doppler API Error {}'.format(err))
+        log('Doppler API Error {}'.format(err.read().decode('utf-8')))
         print_debug_info(doppler_token, project, config)
 
 

--- a/src/doppler_env/__init__.py
+++ b/src/doppler_env/__init__.py
@@ -17,7 +17,7 @@ def log(message):
 
 
 def print_debug_info(doppler_token=None, project=None, config=None):
-    doppler_token and log('Token: {}'.format(doppler_token))
+    doppler_token and log('Token: {}.*****'.format('.'.join(doppler_token.split('.')[:-1])))
     project and log('Project: {}'.format(project))
     config and log('Config: {}'.format(config))
     log('Python path: {}'.format(sys.executable))

--- a/src/doppler_env/__init__.py
+++ b/src/doppler_env/__init__.py
@@ -1,26 +1,52 @@
 """
 Imported by doppler_env.pth Automatically inject Doppler secrets as environment variables when spawning a Python process if the `DOPPLER_ENV` environment variable is set
 """
+from base64 import b64encode
+import io
 import os
+import subprocess
+import sys
+import urllib.request
+import urllib.error
 
+from dotenv import load_dotenv
 
-def doppler_secrets_env():
-    import io
-    import subprocess
-    from dotenv import load_dotenv
+def print_debug_info():
+    print(f'Python path: {sys.executable}')
+    print(f'Working directory: {os.getcwd()}')
 
+def fetch_cli():
     DOPPLER_ENV_COMMAND = os.environ.get(
         'DOPPLER_ENV_COMMAND', 'doppler secrets download --no-file --format env'
     )
 
     # If non-zero exit code, catch Python exception so only output is stderr from Doppler CLI
     try:
-        env_vars = subprocess.check_output(DOPPLER_ENV_COMMAND.split()).decode('utf-8')
+        return subprocess.check_output(DOPPLER_ENV_COMMAND.split()).decode('utf-8')
     except subprocess.CalledProcessError as err:
-        exit(err.returncode)
+        print_debug_info()
 
+
+def fetch_api(doppler_token, format):    
+    auth_header = b'Basic %s' % b64encode(f'{doppler_token}:'.encode('ascii'))
+    url = 'https://api.doppler.com/v3/configs/config/secrets/download?format=%s' % format
+    headers = {'User-Agent': 'python-doppler-env', 'Authorization': auth_header}
+    request = urllib.request.Request(url, headers=headers)
+    
+    try:
+        response = urllib.request.urlopen(request)
+        return response.read().decode('utf-8')
+    except urllib.error.HTTPError as err:
+        print('Doppler API Error: %s' % err)
+        print_debug_info()
+
+
+if os.environ.get('DOPPLER_ENV') is not None:    
+    if(os.environ.get('DOPPLER_TOKEN')):
+        print('DOPPLER_ENV and DOPPLER_TOKEN environment variable set. Fetching secrets from Doppler API.\n')
+        env_vars = fetch_api(os.environ.get('DOPPLER_TOKEN'), format='env')
+    else:
+        print('DOPPLER_ENV environment variable set. Fetching secrets using Doppler CLI.\n')
+        env_vars = fetch_cli()
+    
     load_dotenv(stream=io.StringIO(env_vars))
-
-
-if os.environ.get('DOPPLER_ENV') is not None:
-    doppler_secrets_env()

--- a/test/app.py
+++ b/test/app.py
@@ -1,7 +1,0 @@
-import os
-
-print(
-    '\n'.join(
-        [f'{key} = {val}' for (key, val) in os.environ.items() if key.find('DOPPLER_') >= 0 and key not in ['DOPPLER_ENV', 'DOPPLER_TOKEN']]
-    )
-)

--- a/test/app.py
+++ b/test/app.py
@@ -1,0 +1,7 @@
+import os
+
+print(
+    '\n'.join(
+        [f'{key} = {val}' for (key, val) in os.environ.items() if key.find('DOPPLER_') >= 0 and key not in ['DOPPLER_ENV', 'DOPPLER_TOKEN']]
+    )
+)


### PR DESCRIPTION
This PR adds improved error reporting in failure cases and supports using the Doppler API if the `DOPPLER_TOKEN` env var is set. 

## Improved error reporting

The Python interpreter path and current working directory are now output on failure, helping to debug scenarios where secrets can be fetched in the terminal but not when debugging in an IDE or editor.

```sh
-> python ~/Projects/python-test-app/app.py 
DOPPLER_ENV environment variable set. Fetching secrets using Doppler CLI.

Unable to download secrets
Doppler Error: You must specify a project
Python path: /Users/chris/.virtualenvs/doppler/bin/python
Working directory: /Users/chris/Projects/mandalorian-gifs-python
```

## Doppler API support

Secrets will be fetched directly from the Doppler API when the `DOPPLER_TOKEN` environment variable is set. This allows for usage in environments without the Doppler CLI or when calling the Doppler CLI from Python is blocked by security policies.

```sh
export DOPPLER_TOKEN="dp.st.dev.XXXXXX"

-> python ~/Projects/python-test-app/app.py
DOPPLER_ENV and DOPPLER_TOKEN environment variable set. Fetching secrets from Doppler API.
```

## Testing

Test locally by installing from the `doppler-api` branch:

```sh
pip install git+https://github.com/DopplerHQ/python-doppler-env.git@doppler-api
```