### PR TITLE
Fixed code checks to not rely on virtual environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
         pip install -r requirements.txt
     - name: Code checks
       run: |
-        make flake8
-        make black
+        flake8 .
+        black --skip-string-normalization --line-length 120 .
     - name: Build
       run: python -m build .
     - name: Publish


### PR DESCRIPTION
The make commands should not have been used in a GitHub Action as they are only suitable in a virtual environment during local development.